### PR TITLE
Remove probability if 0

### DIFF
--- a/store/filters.js
+++ b/store/filters.js
@@ -56,7 +56,7 @@ export default class Filters extends VuexModule {
       oid: this.oid,
       selectedClassifier: this.selectedClassifier,
       selectedClass: this.selectedClass,
-      probability: this.probability,
+      probability: this.probability > 0 ? this.probability : null,
       ndet: this.ndet,
     }
   }


### PR DESCRIPTION
- Still a bug when a probability is selected but no classifier, this will show a row for each classifier 

