### PR TITLE
fix #248. Show non detections in lc

### DIFF
--- a/components/cardLightCurve.vue
+++ b/components/cardLightCurve.vue
@@ -20,7 +20,7 @@
           <alerce-light-curve-plot
             slot="difference"
             :detections="lightcurve.detections"
-            :non-detections="lightcurve['non_detections']"
+            :non-detections="lightcurve.nonDetections"
             type="difference"
             :dark="isDark"
           />


### PR DESCRIPTION
Close  #248

**Problem:** Don't display non detections

**Solution:** Change the name of variable in light curve card. non_detections to nonDetections


https://github.com/alercebroker/ztf_explorer/blob/0aaad93a60ad808da025e1a61edeb94418d9c142/components/cardLightCurve.vue#L20-L26
