### PR TITLE
Improvements in lightcurve and search by list of oids

### DIFF
--- a/components/cardLightCurve.vue
+++ b/components/cardLightCurve.vue
@@ -74,7 +74,7 @@ export default class CardLightCurve extends Vue {
 
   @Prop({ type: Number | String, default: 12 }) sm
 
-  @Prop({ type: Number, default: 1 }) period
+  @Prop({ type: Number, default: null }) period
 
   @Prop({ type: Boolean, default: true }) show
 
@@ -146,7 +146,7 @@ export default class CardLightCurve extends Vue {
           x.default = !val.corrected
           break
         case 'folded':
-          x.show = val.corrected
+          x.show = this.period !== null
           break
       }
     })

--- a/components/cardLightCurve.vue
+++ b/components/cardLightCurve.vue
@@ -146,7 +146,7 @@ export default class CardLightCurve extends Vue {
           x.default = !val.corrected
           break
         case 'folded':
-          x.show = this.period !== null
+          x.show = this.period !== null && val.corrected
           break
       }
     })

--- a/components/cardLightCurve.vue
+++ b/components/cardLightCurve.vue
@@ -145,6 +145,9 @@ export default class CardLightCurve extends Vue {
         case 'difference':
           x.default = !val.corrected
           break
+        case 'folded':
+          x.show = val.corrected
+          break
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@alerce/components": "0.0.10-dev",
+    "@alerce/components": "0.0.11-dev",
     "@nuxtjs/axios": "^5.11.0",
     "@nuxtjs/toast": "^3.3.1",
     "@nuxtjs/vuetify": "^1.11.2",

--- a/pages/object/_oid.vue
+++ b/pages/object/_oid.vue
@@ -130,17 +130,9 @@ export default class ObjectView extends Vue {
       (x) => x.name === 'Multiband_period'
     )
     if (periods.length === 0) {
-      return 1
-    } else if (periods.length === 1) {
-      return periods[0].value
+      return null
     } else {
-      const nDet = this.$store.state.features.features.filter(
-        (x) => x.name === 'n_det'
-      )
-      const max = nDet.reduce((prev, current) =>
-        prev.value > current.value ? prev : current
-      )
-      return periods.find((x) => x.fid === max.fid).value
+      return periods[0].value
     }
   }
 

--- a/store/filters.js
+++ b/store/filters.js
@@ -6,7 +6,7 @@ import {
 } from 'nuxt-property-decorator'
 import { objectsStore, paginationStore } from '~/store'
 const defaultState = {
-  oid: null,
+  oid: [],
   selectedClassifier: null,
   selectedClass: null,
   classifiers: [],


### PR DESCRIPTION
Closes  #178
Closes  #282

- Fix boundaries in light curve. Now is automatic with max sigma in each case
- Compatible with a list of oids
- Disabled folded light curve when period is null
