### PR TITLE
Feature: Classifier model priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ sw.*
 # Deploy files
 deploy.sh
 .awspublish-*
+
+# Nix
+flake.lock
+flake.nix

--- a/components/cardClassifiers.vue
+++ b/components/cardClassifiers.vue
@@ -44,6 +44,7 @@
 
 <script>
 import { Vue, Component, Prop } from 'nuxt-property-decorator'
+import { filterSortClassifiers } from '../utils/classifier_sort'
 
 @Component
 export default class CardClassifiers extends Vue {
@@ -99,14 +100,18 @@ export default class CardClassifiers extends Vue {
   get classifiers_() {
     const grouped = this.groupBy(this.classifiers, 'classifier_name')
     const keys = Object.keys(grouped)
-    const res = []
-    keys.forEach((k, i) => {
+    let res = []
+    keys.forEach((k) => {
       const latestVersion = this.getLatestVersion(grouped[k])
       res.push({
-        name: this.formatClassifierName(k),
+        name: k,
         probs: this.formatProbs(grouped[k], latestVersion),
-        index: i,
       })
+    })
+    res = filterSortClassifiers(res)
+    res.map((r, idx) => {
+      r.name = this.formatClassifierName(r.name)
+      r.index = idx
     })
     return res
   }

--- a/components/cardLightCurve.vue
+++ b/components/cardLightCurve.vue
@@ -80,12 +80,14 @@ export default class CardLightCurve extends Vue {
 
   _loadHtmx(objectId) {
     const url = new URL(
-      `/v2/lightcurve/htmx/lightcurve?oid=${objectId}`,
+      '/v2/lightcurve/htmx/lightcurve',
       this.$config.alerceApiBaseUrl
-    ).toString()
+    )
+    url.searchParams.append('oid', objectId)
+
     const myDiv = document.getElementById('lightcurve-app')
     if (myDiv) {
-      myDiv.innerHTML = `<div hx-get=${url} hx-trigger="updateLightcurve once from:body" hx-swap="outerHTML"></div>`
+      myDiv.innerHTML = `<div hx-get=${url.toString()} hx-trigger="updateLightcurve once from:body" hx-swap="outerHTML"></div>`
       htmx.process(myDiv)
       document.body.dispatchEvent(new Event('updateLightcurve'))
     }

--- a/components/cardLightCurve.vue
+++ b/components/cardLightCurve.vue
@@ -79,7 +79,10 @@ export default class CardLightCurve extends Vue {
   }
 
   _loadHtmx(objectId) {
-    const url = `${this.$config.ztfApiv2Url}/lightcurve/htmx/lightcurve?oid=${objectId}`
+    const url = new URL(
+      `/v2/lightcurve/htmx/lightcurve?oid=${objectId}`,
+      this.$config.alerceApiBaseUrl
+    ).toString()
     const myDiv = document.getElementById('lightcurve-app')
     if (myDiv) {
       myDiv.innerHTML = `<div hx-get=${url} hx-trigger="updateLightcurve once from:body" hx-swap="outerHTML"></div>`

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -93,16 +93,12 @@ export default {
    */
   publicRuntimeConfig: {
     avroApiBaseUrl:
-      process.env.AVRO_API_BASE_URL || 'https://dev.avro.alerce.online',
+      process.env.AVRO_API_BASE_URL || 'https://avro.alerce.online',
     catshtmApiBaseUrl:
       process.env.CATSHTM_API_BASE_URL || 'https://catshtm.alerce.online',
     tnsApiBaseUrl: process.env.TNS_API_BASE_URL || 'https://tns.alerce.online',
-    drApiBaseUrl:
-      process.env.ZTF_DR_API_BASE_URL || 'https://api.alerce.online/ztf/dr/v1',
-    ztfApiBaseUrl:
-      process.env.ZTF_API_BASE_URL ||
-      'https://dev-api.alerce.online/alerts/v1/',
-    ztfApiv2Url: process.env.ZTF_V2_API_URL || 'https://api.alerce.online/v2',
+    alerceApiBaseUrl:
+      process.env.ALERCE_API_BASE_URL || 'https://api.alerce.online/',
     usersApiBaseUrl:
       process.env.USERS_API_BASE_URL || 'https://dev.users.alerce.online/users',
     googleRedirectUri:

--- a/plugins/dataReleaseApi.js
+++ b/plugins/dataReleaseApi.js
@@ -1,6 +1,6 @@
 export default function ({ $axios, $config }, inject) {
   const dataReleaseApi = $axios.create({
-    baseURL: $config.drApiBaseUrl,
+    baseURL: new URL('/ztf/dr/v1', $config.alerceApiBaseUrl).toString(),
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/plugins/ztfApi.js
+++ b/plugins/ztfApi.js
@@ -29,10 +29,10 @@ function filterFunc(prefix, value) {
 
 export default function ({ $axios, $config }, inject) {
   const ztfApi = $axios.create({
-    baseURL: $config.ztfApiBaseUrl,
+    baseURL: new URL('/alerts/v1', $config.alerceApiBaseUrl).toString(),
   })
-  const ztfApiv2 = $axios.create({
-    baseURL: $config.ztfApiv2Url,
+  const lightcurveApi = $axios.create({
+    baseURL: new URL('/v2/lightcurve', $config.alerceApiBaseUrl).toString(),
   })
 
   ztfApi.search = (searchParameters, request) => {
@@ -83,7 +83,7 @@ export default function ({ $axios, $config }, inject) {
         'AUTH-TOKEN': token,
       }
     }
-    return ztfApiv2.get(`/lightcurve/lightcurve/${objectId}`, config)
+    return lightcurveApi.get(`/lightcurve/${objectId}`, config)
   }
 
   ztfApi.getStats = (oid, request = null) => {

--- a/store/filters.js
+++ b/store/filters.js
@@ -4,6 +4,7 @@ import {
   VuexMutation,
   VuexAction,
 } from 'nuxt-property-decorator'
+import { filterSortClassifiers } from '../utils/classifier_sort'
 import { objectsStore, paginationStore } from '~/store'
 const defaultState = {
   oid: [],
@@ -201,6 +202,7 @@ export default class Filters extends VuexModule {
       x.name = x.classifier_name
       return x
     })
+    this.classifiers = filterSortClassifiers(this.classifiers)
   }
 
   @VuexMutation

--- a/utils/classifier_sort.js
+++ b/utils/classifier_sort.js
@@ -1,11 +1,12 @@
 const priorities = {
-  lc_classifier: 1,
-  lc_classifier_top: 2,
-  stamp_classifier: 3,
+  lc_classifier: 0,
+  lc_classifier_top: 1,
+  stamp_classifier: 2,
+  'LC_classifier_ATAT_forced_phot(beta)': 3,
+  'LC_classifier_BHRF_forced_phot(beta)': 4,
 }
-
 export function filterSortClassifiers(classifiers) {
   return classifiers
     .filter((classifier) => classifier.name in priorities)
-    .sort((a, b) => priorities[a] - priorities[b])
+    .sort((a, b) => priorities[a.name] - priorities[b.name])
 }

--- a/utils/classifier_sort.js
+++ b/utils/classifier_sort.js
@@ -1,0 +1,11 @@
+const priorities = {
+  lc_classifier: 1,
+  lc_classifier_top: 2,
+  stamp_classifier: 3,
+}
+
+export function filterSortClassifiers(classifiers) {
+  return classifiers
+    .filter((classifier) => classifier.name in priorities)
+    .sort((a, b) => priorities[a] - priorities[b])
+}


### PR DESCRIPTION
Added a helper function to filter and sort the classifier models based on a priority list hardcoded into `utils/classifier_sort.js` (this should probably be read from an API in the future).

This change applies to classifier list displayed in the object browser, as well as the list displayed on the classifier plot.